### PR TITLE
add getters for all properties of each model

### DIFF
--- a/models/CategoryModel.ts
+++ b/models/CategoryModel.ts
@@ -37,6 +37,10 @@ export default class CategoryModel extends Model<Category> {
       return unsubscribe
    }
 
+   get id()          { return this.category.id }
+   get name()        { return this.category.name }
+   get listOrder()   { return this.category.listOrder }
+
    static listenToQuery(q: Query, setFunction: Function): Unsubscribe {
       const unsubscribe = onSnapshot(q, snapshot => {
          const categories: CategoryModel[] = []

--- a/models/FlavorModel.ts
+++ b/models/FlavorModel.ts
@@ -50,6 +50,11 @@ import { Flavor } from './interfaces';
          return unsubscribe
       }
 
+      get id()          { return this.flavor.id }
+      get name()        { return this.flavor.name }
+      get price()       { return this.flavor.price }
+      get isAvailable() { return this.flavor.isAvailable }
+
       values() {
          return this.flavor
       }

--- a/models/MenuItemModel.ts
+++ b/models/MenuItemModel.ts
@@ -79,6 +79,21 @@ export default class MenuItemModel extends Model<MenuItem> {
       return unsubscribe
    }
 
+   get id()          { return this.menuItem.id }
+   get name()        { return this.menuItem.name }
+   get price()       { return this.menuItem.price }
+   get isAvailable() { return this.menuItem.isAvailable }
+   get categoryId()  { return this.menuItem.categoryId }
+   get options()     { return this.menuItem.options }
+   get uniqOptions() { return this.menuItem.uniqOptions }
+   get flavorIds()   { return this.menuItem.flavorIds }
+   get toppingIds()  { return this.menuItem.toppingIds }
+   get sauceIds()    { return this.menuItem.sauceIds }
+   get description() { return this.menuItem.description }
+   get listOrder()   { return this.menuItem.listOrder }
+   get img()         { return this.menuItem.img }
+   get promoPrice()  { return this.menuItem.promoPrice }
+
    values() {
       return this.menuItem
    }

--- a/models/OrderModel.ts
+++ b/models/OrderModel.ts
@@ -65,6 +65,13 @@ export default class OrderModel extends Model<Order> {
       return unsubscribe
    }
 
+   get id()          { return this.order.id }
+   get totalPrice()  { return this.order.totalPrice }
+   get codeNumber()  { return this.order.codeNumber }
+   get status()      { return this.order.status }
+   get items()       { return this.order.items }
+   get dateTime()    { return this.order.dateTime }
+
    values() {
       return this.order
    }

--- a/models/SauceModel.ts
+++ b/models/SauceModel.ts
@@ -50,6 +50,11 @@ export default class SauceModel extends Model<Sauce> {
       return unsubscribe
    }
 
+   get id()          { return this.sauce.id }
+   get name()        { return this.sauce.name }
+   get price()       { return this.sauce.price }
+   get isAvailable() { return this.sauce.isAvailable }
+
    values() {
       return this.sauce
    }

--- a/models/ToppingModel.ts
+++ b/models/ToppingModel.ts
@@ -50,6 +50,11 @@ export default class ToppingModel extends Model<Topping> {
       return unsubscribe
    }
 
+   get id()          { return this.topping.id }
+   get name()        { return this.topping.name }
+   get price()       { return this.topping.price }
+   get isAvailable() { return this.topping.isAvailable }
+
    values() {
       return this.topping
    }


### PR DESCRIPTION
Resolves #23 

This PR intends to improve the usability and accessibility of the values of the models.
Previously to access any of the values something like this should be done:
`const toppingId = topping.values().id`
or
`const { name } = menuItem.values()`
With the addition of the getters we now will be able to access the properties as if they were direct members of the `Model` type
in the following way:
`topping.id`, `menuItem.name`