### PR TITLE
singleItem checkbox fixed

### DIFF
--- a/components/ItemsPage/AddOns/AddOns.tsx
+++ b/components/ItemsPage/AddOns/AddOns.tsx
@@ -61,6 +61,9 @@ const AddOns = ({
       ElementReffed.current.forEach((el) => {
          el.id === idValue &&
             changeCheckBoxClass(el.parentElement?.parentElement?.parentElement, bool)
+         singleOption &&
+            el.id !== idValue &&
+            changeCheckBoxClass(el.parentElement?.parentElement?.parentElement, false)
       })
    }
    const setAllValues = (

--- a/components/ItemsPage/ItemsPage.tsx
+++ b/components/ItemsPage/ItemsPage.tsx
@@ -30,10 +30,8 @@ const ItemsPage = (props: Props) => {
    const { menuItems, toppings, sauces, menuItemOptions } = useContext(menuContext)
 
    const { settingsModel } = useContext(settingsContext)
-   const maxAmount = settingsModel?.maxAmountOfAddons ? settingsModel?.maxAmountOfAddons : 0
-   const toppingsAllowed = settingsModel?.allowUserToAddToppings
-      ? settingsModel?.allowUserToAddToppings
-      : false
+   const maxAmount = settingsModel?.maxAmountOfAddons ?? 0
+   const toppingsAllowed = settingsModel?.allowUserToAddToppings ?? false
 
    const definePrice = (serverDate?: Date) => {
       let price = 0
@@ -149,12 +147,14 @@ const ItemsPage = (props: Props) => {
          return false
       return true
    }
+   const [isUseEffectSecondLoad, setIsUseEffectSecondLoad] = useState(false)
    const [dialog, setDialog] = useState(false)
    const router = useRouter()
    const [buttonState, setButtonState] = useState(defineButtonState())
    useEffect(() => {
       setButtonState(defineButtonState(addOns))
-      !theItem?.isAvailable && setDialog(true)
+      isUseEffectSecondLoad && !theItem?.isAvailable && setDialog(true)
+      !isUseEffectSecondLoad && setIsUseEffectSecondLoad(true)
    }, [addOns, theItem])
 
    return (

--- a/hooks/useMultipleStatesManager.ts
+++ b/hooks/useMultipleStatesManager.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { stringToArray } from '../utils/dataHelper'
 
 interface MultipleStates {
@@ -28,7 +28,7 @@ const useMultipleStatesManager = <T extends { id: string; price: number | undefi
    }
 
    modelList.forEach((add) => {
-      appendedLightBoxes(add.id, add.price ? add.price : 0, stringToArray(url).includes(add.id))
+      appendedLightBoxes(add.id, add.price ?? 0, stringToArray(url).includes(add.id))
    })
 
    const newIds = lightBoxes.map((box) => box.state && box.id).filter(Boolean) as string[]
@@ -37,7 +37,8 @@ const useMultipleStatesManager = <T extends { id: string; price: number | undefi
       if (singleOption) {
          const tempBoxes = [...lightBoxes]
          tempBoxes.forEach((box) => {
-            box.id !== currentId ? box.setState(false) : box.setState(true)
+            box.id !== currentId && box.setState(false)
+            box.id === currentId && box.setState(!box.state)
          })
       } else if (maxAmount !== undefined && maxAmount !== 0) {
          const currentObj = lightBoxes[index]


### PR DESCRIPTION
Resolves #155 

Besides the problem related in the isseu 155 I also realized that whenever we would reload and `item` page it would display the message as if that item was unavailable. To fix this I created a state to know if it was the first time the `useEffect` in which we check if the item is available ran. This state variable is placed in line 150 as follow:

`const [isUseEffectSecondLoad, setIsUseEffectSecondLoad] = useState(false)`

From line 154 to 158 is where the `useEffect` runs as follow:

```
useEffect(() => {
      setButtonState(defineButtonState(addOns))
      isUseEffectSecondLoad && !theItem?.isAvailable && setDialog(true)
      !isUseEffectSecondLoad && setIsUseEffectSecondLoad(true)
   }, [addOns, theItem])
```

This avoid the unavailable message right after the page is loaded and is only displayed when the item is indeed unavailable.